### PR TITLE
Fix docstring typo

### DIFF
--- a/tests/resources.py
+++ b/tests/resources.py
@@ -29,7 +29,7 @@ async def test_lock_file_removed(tmp_path: Path) -> None:
 
 async def test_lock_path_released(tmp_path: Path) -> None:
     """
-    Test tat the lock can be acquired again after the context manager exits.
+    Test that the lock can be acquired again after the context manager exits.
     """
     async with asyncio.timeout(5):
         async with file_lock(str(tmp_path)):


### PR DESCRIPTION
## Summary
- fix a typo in the tests docstring

## Testing
- `make test` *(fails: Failed to spawn: `deptry`)*

------
https://chatgpt.com/codex/tasks/task_e_683f467105d88331a829a9882c392e8f